### PR TITLE
FIXED overflow on fp16

### DIFF
--- a/SMAA/Shaders/SMAA.cginc
+++ b/SMAA/Shaders/SMAA.cginc
@@ -1271,7 +1271,7 @@ float4 SMAANeighborhoodBlendingPS(float2 texcoord,
 
     // Is there any blending weight with a value greater than 0.0?
     SMAA_BRANCH
-    if (dot(a, float4(1.0, 1.0, 1.0, 1.0)) < 1e-5) {
+    if (dot(a, float4(1.0, 1.0, 1.0, 1.0)) < 1e-3) {
         float4 color = SMAASampleLevelZero(colorTex, texcoord);
 
         #if SMAA_REPROJECTION


### PR DESCRIPTION
I have tested SMAA on android Mali400 GPU, and found a bug with comparison. May be I understand not all of the cases and this can introduce some new bugs. But after tests in my data - it's work ok.