### PR TITLE
Update MinDrawer.cs - Ambiguous type error

### DIFF
--- a/SMAA/Scripts/Editor/MinDrawer.cs
+++ b/SMAA/Scripts/Editor/MinDrawer.cs
@@ -27,12 +27,12 @@ using Smaa;
 
 namespace SmaaEditor
 {
-	[CustomPropertyDrawer(typeof(MinAttribute))]
+	[CustomPropertyDrawer(typeof(Smaa.MinAttribute))]
 	internal sealed class MinDrawer : PropertyDrawer
 	{
 		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
 		{
-			MinAttribute attribute = (MinAttribute)base.attribute;
+            Smaa.MinAttribute attribute = (Smaa.MinAttribute)base.attribute;
 
 			if (property.propertyType == SerializedPropertyType.Integer)
 			{


### PR DESCRIPTION
Simple fix to the "ambiguous type" error thown by Unity.